### PR TITLE
Add support for pandeguardium robot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2023.3.2"
+    id "edu.wpi.first.GradleRIO" version "2023.4.1"
     id 'com.diffplug.spotless' version '6.14.1'
 }
 

--- a/src/main/java/com/frc5113/robot/RobotContainer.java
+++ b/src/main/java/com/frc5113/robot/RobotContainer.java
@@ -4,10 +4,11 @@
 
 package com.frc5113.robot;
 
+import static com.frc5113.robot.constants.DrivetrainConstants.ROBOT_VERSION;
 import static com.frc5113.robot.constants.GeneralConstants.LOOP_DT;
+
 import com.frc5113.library.loops.Looper;
 import com.frc5113.library.loops.SubsystemManager;
-import static com.frc5113.robot.constants.DrivetrainConstants.ROBOT_VERSION;
 import com.frc5113.robot.commands.auto.Autos;
 import com.frc5113.robot.commands.drive.*;
 import com.frc5113.robot.commands.drive.D_TeleopDrive;

--- a/src/main/java/com/frc5113/robot/RobotContainer.java
+++ b/src/main/java/com/frc5113/robot/RobotContainer.java
@@ -14,7 +14,7 @@ import com.frc5113.robot.commands.drive.*;
 import com.frc5113.robot.commands.drive.D_TeleopDrive;
 import com.frc5113.robot.commands.photonvision.*;
 import com.frc5113.robot.oi.IOI;
-import com.frc5113.robot.oi.JoystickOI;
+import com.frc5113.robot.oi.XboxOI;
 import com.frc5113.robot.subsystems.*;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
@@ -43,8 +43,11 @@ public class RobotContainer {
   /** Arm/truss subsystem */
   private final S_Arm arm = new S_Arm();
 
+  /** Gyro subsystem */
+  private final S_Gyro gyro = new S_Gyro();
+
   // Operator interface
-  private final IOI controller1 = new JoystickOI();
+  private final IOI controller1 = new XboxOI();
 
   // subsystem manager
   private final Looper enabledLoop =
@@ -69,6 +72,11 @@ public class RobotContainer {
 
     // Configure the trigger bindings
     configureBindings();
+
+    // Register subsystems to subsystemmanager and loops
+    manager.registerEnabledLoops(enabledLoop);
+    manager.registerDisabledLoops(disabledLoop);
+    manager.setSubsystems(driveTrain, claw, arm, pneumatics, gyro, photonVision);
   }
 
   /**
@@ -94,11 +102,7 @@ public class RobotContainer {
     return Autos.driveBackward(driveTrain); // Do Nothing: new InstantCommand(() -> {});
   }
 
-  public void robotInit() {
-    manager.registerEnabledLoops(enabledLoop);
-    manager.registerDisabledLoops(disabledLoop);
-    manager.setSubsystems(driveTrain, claw, arm, pneumatics);
-  }
+  public void robotInit() {}
 
   public void robotPeriodic() {
     manager.outputToSmartDashboard();

--- a/src/main/java/com/frc5113/robot/RobotContainer.java
+++ b/src/main/java/com/frc5113/robot/RobotContainer.java
@@ -5,9 +5,9 @@
 package com.frc5113.robot;
 
 import static com.frc5113.robot.constants.GeneralConstants.LOOP_DT;
-
 import com.frc5113.library.loops.Looper;
 import com.frc5113.library.loops.SubsystemManager;
+import static com.frc5113.robot.constants.DrivetrainConstants.ROBOT_VERSION;
 import com.frc5113.robot.commands.auto.Autos;
 import com.frc5113.robot.commands.drive.*;
 import com.frc5113.robot.commands.drive.D_TeleopDrive;
@@ -28,7 +28,7 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
 public class RobotContainer {
   // Robot subsystems
   /** Neo Drivetrain responsible for robot movement (Subsystem) */
-  private final S_DriveTrain driveTrain = new S_DriveTrain();
+  private final DriveTrain driveTrain;
 
   /** General pneumatics controller from which pneumatic components are derived */
   private final S_Pneumatics pneumatics = new S_Pneumatics();
@@ -57,6 +57,18 @@ public class RobotContainer {
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
+    switch (ROBOT_VERSION) {
+      case Pandemonium:
+        driveTrain = new S_DriveTrainPandemonium();
+        break;
+      case Pandeguardium:
+        driveTrain = new S_DriveTrainPandeguardium();
+        break;
+      default:
+        driveTrain = new S_DriveTrainPandemonium();
+        break;
+    }
+
     // Configure the trigger bindings
     configureBindings();
 

--- a/src/main/java/com/frc5113/robot/RobotContainer.java
+++ b/src/main/java/com/frc5113/robot/RobotContainer.java
@@ -14,7 +14,7 @@ import com.frc5113.robot.commands.drive.*;
 import com.frc5113.robot.commands.drive.D_TeleopDrive;
 import com.frc5113.robot.commands.photonvision.*;
 import com.frc5113.robot.oi.IOI;
-import com.frc5113.robot.oi.JoystickOI;
+import com.frc5113.robot.oi.XboxOI;
 import com.frc5113.robot.subsystems.*;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
@@ -47,7 +47,7 @@ public class RobotContainer {
   private final S_Gyro gyro = new S_Gyro();
 
   // Operator interface
-  private final IOI controller1 = new JoystickOI();
+  private final IOI controller1 = new XboxOI();
 
   // subsystem manager
   private final Looper enabledLoop =

--- a/src/main/java/com/frc5113/robot/RobotContainer.java
+++ b/src/main/java/com/frc5113/robot/RobotContainer.java
@@ -5,9 +5,9 @@
 package com.frc5113.robot;
 
 import static com.frc5113.robot.constants.GeneralConstants.LOOP_DT;
-
 import com.frc5113.library.loops.Looper;
 import com.frc5113.library.loops.SubsystemManager;
+import static com.frc5113.robot.constants.DrivetrainConstants.ROBOT_VERSION;
 import com.frc5113.robot.commands.auto.Autos;
 import com.frc5113.robot.commands.drive.*;
 import com.frc5113.robot.commands.drive.D_TeleopDrive;
@@ -28,7 +28,7 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
 public class RobotContainer {
   // Robot subsystems
   /** Neo Drivetrain responsible for robot movement (Subsystem) */
-  private final S_DriveTrain driveTrain = new S_DriveTrain();
+  private final DriveTrain driveTrain;
 
   /** General pneumatics controller from which pneumatic components are derived */
   private final S_Pneumatics pneumatics = new S_Pneumatics();
@@ -54,6 +54,18 @@ public class RobotContainer {
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
+    switch (ROBOT_VERSION) {
+      case Pandemonium:
+        driveTrain = new S_DriveTrainPandemonium();
+        break;
+      case Pandeguardium:
+        driveTrain = new S_DriveTrainPandeguardium();
+        break;
+      default:
+        driveTrain = new S_DriveTrainPandemonium();
+        break;
+    }
+
     // Configure the trigger bindings
     configureBindings();
   }

--- a/src/main/java/com/frc5113/robot/RobotContainer.java
+++ b/src/main/java/com/frc5113/robot/RobotContainer.java
@@ -4,6 +4,8 @@
 
 package com.frc5113.robot;
 
+import static com.frc5113.robot.constants.DrivetrainConstants.ROBOT_VERSION;
+
 import com.frc5113.robot.commands.auto.Autos;
 import com.frc5113.robot.commands.drive.D_TeleopDrive;
 import com.frc5113.robot.oi.IOI;
@@ -22,7 +24,7 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
 public class RobotContainer {
   // Robot subsystems
   /** Neo Drivetrain responsible for robot movement (Subsystem) */
-  private final S_DriveTrain driveTrain = new S_DriveTrain();
+  private final DriveTrain driveTrain;
 
   /** General pneumatics controller from which pneumatic components are derived */
   private final S_Pneumatics pneumatics = new S_Pneumatics();
@@ -38,6 +40,18 @@ public class RobotContainer {
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
+    switch (ROBOT_VERSION) {
+      case Pandemonium:
+        driveTrain = new S_DriveTrainPandemonium();
+        break;
+      case Pandeguardium:
+        driveTrain = new S_DriveTrainPandeguardium();
+        break;
+      default:
+        driveTrain = new S_DriveTrainPandemonium();
+        break;
+    }
+
     // Configure the trigger bindings
     configureBindings();
   }

--- a/src/main/java/com/frc5113/robot/commands/auto/A_AutoDrive.java
+++ b/src/main/java/com/frc5113/robot/commands/auto/A_AutoDrive.java
@@ -4,14 +4,14 @@
 
 package com.frc5113.robot.commands.auto;
 
-import com.frc5113.robot.subsystems.S_DriveTrain;
+import com.frc5113.robot.subsystems.DriveTrain;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import java.util.function.Supplier;
 
 public class A_AutoDrive extends CommandBase {
   /** Creates a new AutoDriveCommand. */
-  private final S_DriveTrain drive;
+  private final DriveTrain drive;
 
   private final Supplier<Double> rightSpeed;
   private final Supplier<Double> leftSpeed;
@@ -28,7 +28,7 @@ public class A_AutoDrive extends CommandBase {
    * @param endTime Time (in seconds) to finish at
    */
   public A_AutoDrive(
-      S_DriveTrain drive, Supplier<Double> leftSpeed, Supplier<Double> rightSpeed, double endTime) {
+      DriveTrain drive, Supplier<Double> leftSpeed, Supplier<Double> rightSpeed, double endTime) {
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(drive);
 

--- a/src/main/java/com/frc5113/robot/commands/auto/Autos.java
+++ b/src/main/java/com/frc5113/robot/commands/auto/Autos.java
@@ -4,7 +4,7 @@
 
 package com.frc5113.robot.commands.auto;
 
-import com.frc5113.robot.subsystems.S_DriveTrain;
+import com.frc5113.robot.subsystems.DriveTrain;
 import edu.wpi.first.wpilibj2.command.Command;
 
 public final class Autos {
@@ -13,20 +13,20 @@ public final class Autos {
     throw new UnsupportedOperationException("This is a utility class!");
   }
 
-  public static Command driveBackward(S_DriveTrain drive) {
+  public static Command driveBackward(DriveTrain drive) {
     return driveBackward(drive, 0.3);
   }
 
-  public static Command driveBackward(S_DriveTrain drive, double power) {
+  public static Command driveBackward(DriveTrain drive, double power) {
     return driveBackward(drive, power, 2);
   }
 
-  public static Command driveBackward(S_DriveTrain drive, double power, double endTime) {
+  public static Command driveBackward(DriveTrain drive, double power, double endTime) {
     return driveBackward(drive, power, power, endTime);
   }
 
   public static Command driveBackward(
-      S_DriveTrain drive, double powerLeft, double powerRight, double endTime) {
+      DriveTrain drive, double powerLeft, double powerRight, double endTime) {
     return new A_AutoDrive(drive, () -> powerLeft, () -> powerRight, endTime);
   }
 }

--- a/src/main/java/com/frc5113/robot/commands/drive/D_TeleopDrive.java
+++ b/src/main/java/com/frc5113/robot/commands/drive/D_TeleopDrive.java
@@ -4,19 +4,19 @@
 
 package com.frc5113.robot.commands.drive;
 
-import com.frc5113.robot.subsystems.S_DriveTrain;
+import com.frc5113.robot.subsystems.DriveTrain;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import java.util.function.Supplier;
 
 public class D_TeleopDrive extends CommandBase {
 
-  private final S_DriveTrain driveTrain;
+  private final DriveTrain driveTrain;
   private final Supplier<Double> leftSpeed;
   private final Supplier<Double> rightSpeed;
 
   /** Creates a new DEF_DriveTrain. */
   public D_TeleopDrive(
-      S_DriveTrain driveTrain, Supplier<Double> leftSpeed, Supplier<Double> rightSpeed) {
+      DriveTrain driveTrain, Supplier<Double> leftSpeed, Supplier<Double> rightSpeed) {
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(driveTrain);
 

--- a/src/main/java/com/frc5113/robot/commands/photonvision/P_CenterToTarget.java
+++ b/src/main/java/com/frc5113/robot/commands/photonvision/P_CenterToTarget.java
@@ -2,7 +2,7 @@ package com.frc5113.robot.commands.photonvision;
 
 import static com.frc5113.robot.constants.PhotonVisionConstants.*;
 
-import com.frc5113.robot.subsystems.S_DriveTrain;
+import com.frc5113.robot.subsystems.DriveTrain;
 import com.frc5113.robot.subsystems.S_PhotonVision;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj2.command.PIDCommand;
@@ -10,7 +10,7 @@ import edu.wpi.first.wpilibj2.command.PIDCommand;
 public class P_CenterToTarget extends PIDCommand {
   private S_PhotonVision photonVision;
 
-  public P_CenterToTarget(S_DriveTrain driveTrain, S_PhotonVision photonVision) {
+  public P_CenterToTarget(DriveTrain driveTrain, S_PhotonVision photonVision) {
     super(
         new PIDController(kP, kI, kD),
         photonVision::getTx,

--- a/src/main/java/com/frc5113/robot/constants/DrivetrainConstants.java
+++ b/src/main/java/com/frc5113/robot/constants/DrivetrainConstants.java
@@ -1,12 +1,23 @@
 package com.frc5113.robot.constants;
 
+import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.frc5113.robot.enums.RobotVersion;
 import com.revrobotics.CANSparkMax.IdleMode;
 
 public class DrivetrainConstants {
-  public static final int LEFT_LEADER_ID = 12;
-  public static final int LEFT_FOLLOWER_ID = 22;
-  public static final int RIGHT_LEADER_ID = 11;
-  public static final int RIGHT_FOLLOWER_ID = 21;
+  public static final RobotVersion ROBOT_VERSION = RobotVersion.Pandeguardium;
 
-  public static final IdleMode MOTOR_MODE = IdleMode.kCoast;
+  public static final int LEFT_LEADER_ID_PANDEMONIUM = 12;
+  public static final int LEFT_FOLLOWER_ID_PANDEMONIUM = 22;
+  public static final int RIGHT_LEADER_ID_PANDEMONIUM = 11;
+  public static final int RIGHT_FOLLOWER_ID_PANDEMONIUM = 21;
+
+  public static final IdleMode MOTOR_MODE_PANDEMONIUM = IdleMode.kBrake;
+
+  public static final int LEFT_LEADER_ID_PANDEGUARDIUM = 11;
+  public static final int LEFT_FOLLOWER_ID_PANDEGUARDIUM = 21;
+  public static final int RIGHT_LEADER_ID_PANDEGUARDIUM = 12;
+  public static final int RIGHT_FOLLOWER_ID_PANDEGUARDIUM = 22;
+
+  public static final NeutralMode MOTOR_MODE_PANDEGUARDIUM = NeutralMode.Brake;
 }

--- a/src/main/java/com/frc5113/robot/enums/RobotVersion.java
+++ b/src/main/java/com/frc5113/robot/enums/RobotVersion.java
@@ -1,0 +1,6 @@
+package com.frc5113.robot.enums;
+
+public enum RobotVersion {
+  Pandemonium,
+  Pandeguardium
+}

--- a/src/main/java/com/frc5113/robot/subsystems/DriveTrain.java
+++ b/src/main/java/com/frc5113/robot/subsystems/DriveTrain.java
@@ -1,0 +1,22 @@
+package com.frc5113.robot.subsystems;
+
+import com.frc5113.library.subsystem.SmartSubsystem;
+import com.frc5113.robot.primative.DrivetrainEncoders;
+import edu.wpi.first.wpilibj.drive.DifferentialDrive;
+import edu.wpi.first.wpilibj.motorcontrol.MotorControllerGroup;
+
+public abstract class DriveTrain extends SmartSubsystem {
+  public abstract void tankDrive(double leftSpeedRaw, double RightSpeedRaw);
+
+  public abstract void arcadeDrive(double arcadeSpeedRaw, double arcadeTurnRaw);
+
+  public abstract void updatePositions();
+
+  public abstract DifferentialDrive getDifferentialDrive();
+
+  public abstract MotorControllerGroup getLeftMotorGroup();
+
+  public abstract MotorControllerGroup getRightMotorGroup();
+
+  public abstract DrivetrainEncoders getEncoders();
+}

--- a/src/main/java/com/frc5113/robot/subsystems/S_DriveTrainPandeguardium.java
+++ b/src/main/java/com/frc5113/robot/subsystems/S_DriveTrainPandeguardium.java
@@ -1,0 +1,174 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package com.frc5113.robot.subsystems;
+
+import static com.frc5113.robot.constants.DrivetrainConstants.*;
+
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
+import com.frc5113.library.loops.ILooper;
+import com.frc5113.library.loops.Loop;
+import com.frc5113.library.motors.SmartFalcon;
+import com.frc5113.library.oi.scalers.CubicCurve;
+import com.frc5113.robot.primative.DrivetrainEncoders;
+import edu.wpi.first.wpilibj.drive.DifferentialDrive;
+import edu.wpi.first.wpilibj.motorcontrol.MotorControllerGroup;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import java.security.InvalidParameterException;
+
+/** The drivetrain, well... drives */
+public class S_DriveTrainPandeguardium extends DriveTrain {
+  private final SmartFalcon leftLeader;
+  private final SmartFalcon leftFollower;
+  private final SmartFalcon rightLeader;
+  private final SmartFalcon rightFollower;
+
+  private final MotorControllerGroup leftGroup;
+  private final MotorControllerGroup rightGroup;
+
+  private final DifferentialDrive drive;
+
+  // encoder values
+  private final DrivetrainEncoders encoders;
+
+  // input scaler
+  private final CubicCurve curve;
+
+  /** Creates a new DriveTrain. */
+  public S_DriveTrainPandeguardium() {
+    leftLeader = new SmartFalcon(LEFT_LEADER_ID_PANDEGUARDIUM, true, MOTOR_MODE_PANDEGUARDIUM);
+    leftFollower = new SmartFalcon(LEFT_FOLLOWER_ID_PANDEGUARDIUM, true, MOTOR_MODE_PANDEGUARDIUM);
+    rightLeader = new SmartFalcon(RIGHT_LEADER_ID_PANDEGUARDIUM, false, MOTOR_MODE_PANDEGUARDIUM);
+    rightFollower =
+        new SmartFalcon(RIGHT_FOLLOWER_ID_PANDEGUARDIUM, false, MOTOR_MODE_PANDEGUARDIUM);
+
+    leftGroup = new MotorControllerGroup(leftLeader, leftFollower);
+    rightGroup = new MotorControllerGroup(rightLeader, rightFollower);
+
+    drive = new DifferentialDrive(leftGroup, rightGroup);
+
+    encoders = new DrivetrainEncoders();
+
+    curve = new CubicCurve();
+  }
+
+  public void tankDrive(double leftSpeedRaw, double rightSpeedRaw) {
+    double leftSpeed = curve.calculateMappedVal(leftSpeedRaw);
+    double rightSpeed = curve.calculateMappedVal(rightSpeedRaw);
+    if (leftSpeed < -1 || leftSpeed > 1 || rightSpeed < -1 || rightSpeed > 1) {
+      throw new InvalidParameterException(
+          "Left=" + leftSpeed + " Right=" + rightSpeed + " - MUST -1 < Left||Right < 1");
+    }
+    drive.tankDrive(leftSpeed, rightSpeed);
+  }
+
+  public void arcadeDrive(double arcadeSpeedRaw, double arcadeTurnRaw) {
+    double arcadeSpeed = curve.calculateMappedVal(arcadeSpeedRaw);
+    double arcadeTurn = curve.calculateMappedVal(arcadeTurnRaw);
+    if (arcadeSpeed < -1 || arcadeSpeed > 1 || arcadeTurn < -1 || arcadeTurn > 1) {
+      throw new InvalidParameterException(
+          "Speed=" + arcadeSpeed + " Turn=" + arcadeTurn + " - MUST -1 < Speed||Turn < 1");
+    }
+    drive.arcadeDrive(arcadeSpeed, arcadeTurn);
+  }
+
+  // Methods required by SmartSubsystem
+  @Override
+  public void outputTelemetry() {
+    SmartDashboard.putData("Drive: Diff Drive", drive);
+    SmartDashboard.putNumber("Drive: Right Leader Enc", rightLeader.getEncoderRotations());
+    SmartDashboard.putNumber("Drive: Left Leader Enc", leftLeader.getEncoderRotations());
+    SmartDashboard.putNumber("Drive: Right Follower Enc", rightFollower.getEncoderRotations());
+    SmartDashboard.putNumber("Drive: Left Follower Enc", leftFollower.getEncoderRotations());
+  }
+
+  @Override
+  public void zeroSensors() {
+    leftLeader.resetEncoder();
+    leftFollower.resetEncoder();
+    rightLeader.resetEncoder();
+    rightFollower.resetEncoder();
+  }
+
+  @Override
+  public boolean checkSubsystem() {
+    return true; // FIXME
+  }
+
+  @Override
+  public void stop() {
+    rightGroup.set(0);
+    leftGroup.set(0);
+  }
+
+  public void updatePositions() {
+    encoders.updateMeasurements(
+        leftLeader.getEncoderRotations(),
+        rightLeader.getEncoderRotations(),
+        leftFollower.getEncoderRotations(),
+        rightFollower.getEncoderRotations());
+  }
+
+  @Override
+  public void readPeriodicInputs() {
+    updatePositions();
+  }
+
+  @Override
+  public void writePeriodicOutputs() {}
+
+  @Override
+  public void registerEnabledLoops(ILooper enabledLooper) {
+    enabledLooper.register(
+        new Loop() {
+          @Override
+          public void onLoop(double arg0) {}
+
+          @Override
+          public void onStart(double arg0) {
+            stop(); // be sure to stop
+            zeroSensors();
+          }
+
+          @Override
+          public void onStop(double arg0) {
+            stop(); // be sure to stop
+            zeroSensors();
+          }
+        });
+  }
+
+  // GETTERS
+  public WPI_TalonFX getLeftFollower() {
+    return leftFollower;
+  }
+
+  public WPI_TalonFX getLeftLeader() {
+    return leftLeader;
+  }
+
+  public WPI_TalonFX getRightFollower() {
+    return rightFollower;
+  }
+
+  public WPI_TalonFX getRightLeader() {
+    return rightLeader;
+  }
+
+  public DifferentialDrive getDifferentialDrive() {
+    return drive;
+  }
+
+  public MotorControllerGroup getLeftMotorGroup() {
+    return leftGroup;
+  }
+
+  public MotorControllerGroup getRightMotorGroup() {
+    return rightGroup;
+  }
+
+  public DrivetrainEncoders getEncoders() {
+    return encoders;
+  }
+}

--- a/src/main/java/com/frc5113/robot/subsystems/S_DriveTrainPandemonium.java
+++ b/src/main/java/com/frc5113/robot/subsystems/S_DriveTrainPandemonium.java
@@ -9,7 +9,6 @@ import static com.frc5113.robot.constants.DrivetrainConstants.*;
 import com.frc5113.library.loops.ILooper;
 import com.frc5113.library.loops.Loop;
 import com.frc5113.library.motors.SmartNeo;
-import com.frc5113.library.subsystem.SmartSubsystem;
 import com.frc5113.robot.primative.DrivetrainEncoders;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.RelativeEncoder;
@@ -19,7 +18,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import java.security.InvalidParameterException;
 
 /** The drivetrain, well... drives */
-public class S_DriveTrain extends SmartSubsystem {
+public class S_DriveTrainPandemonium extends DriveTrain {
   private final SmartNeo leftLeader;
   private final SmartNeo leftFollower;
   private final SmartNeo rightLeader;
@@ -39,11 +38,11 @@ public class S_DriveTrain extends SmartSubsystem {
   private final DrivetrainEncoders encoders;
 
   /** Creates a new DriveTrain. */
-  public S_DriveTrain() {
-    leftLeader = new SmartNeo(LEFT_LEADER_ID, MOTOR_MODE);
-    leftFollower = new SmartNeo(LEFT_FOLLOWER_ID, MOTOR_MODE);
-    rightLeader = new SmartNeo(RIGHT_LEADER_ID, MOTOR_MODE);
-    rightFollower = new SmartNeo(RIGHT_FOLLOWER_ID, MOTOR_MODE);
+  public S_DriveTrainPandemonium() {
+    leftLeader = new SmartNeo(LEFT_LEADER_ID_PANDEMONIUM, MOTOR_MODE_PANDEMONIUM);
+    leftFollower = new SmartNeo(LEFT_FOLLOWER_ID_PANDEMONIUM, MOTOR_MODE_PANDEMONIUM);
+    rightLeader = new SmartNeo(RIGHT_LEADER_ID_PANDEMONIUM, MOTOR_MODE_PANDEMONIUM);
+    rightFollower = new SmartNeo(RIGHT_FOLLOWER_ID_PANDEMONIUM, MOTOR_MODE_PANDEMONIUM);
 
     leftGroup = new MotorControllerGroup(leftLeader, leftFollower);
     rightGroup = new MotorControllerGroup(rightLeader, rightFollower);
@@ -69,6 +68,14 @@ public class S_DriveTrain extends SmartSubsystem {
           "Left=" + leftSpeed + " Right=" + rightSpeed + " - MUST -1 < Left||Right < 1");
     }
     drive.tankDrive(leftSpeed, rightSpeed);
+  }
+
+  public void arcadeDrive(double arcadeSpeed, double arcadeTurn) {
+    if (arcadeSpeed < -1 || arcadeSpeed > 1 || arcadeTurn < -1 || arcadeTurn > 1) {
+      throw new InvalidParameterException(
+          "Speed=" + arcadeSpeed + " Turn=" + arcadeTurn + " - MUST -1 < Speed||Turn < 1");
+    }
+    drive.arcadeDrive(arcadeSpeed, arcadeTurn);
   }
 
   // Methods required by SmartSubsystem


### PR DESCRIPTION
done so that the old-robot branch can die a peaceful death
this entails:
- creating two separate drivetrain subsystems which extend the DriveTrain abstract class
- more constants
- adding arcadedrive to the 2023 drivetrain for compliance with DriveTrain
- changing the oi type to xbox for comfort

there may be a bit of a hiccup in that the motor getters don't work when the drivetrains are instantiated as DriveTrains

ignore the atrocious git shenanigans